### PR TITLE
Fix GitHub token pass-through

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,7 +28,13 @@ FastAPI backend for the DesignX browser extension, providing secure GitHub OAuth
      - Authorization callback URL: `http://localhost:8000/api/github/callback`
    - Copy the Client ID and Client Secret to your `.env` file
 
-4. **Run the server:**
+4. **Ensure token permissions:**
+   The OAuth token requested by the extension must include the `repo` scope so
+   SWE-Agent can clone private repositories and open pull requests directly in
+   your workspace. The default configuration already requests `repo` and
+   `read:user` permissions.
+
+5. **Run the server:**
    ```bash
    python main.py
    ```

--- a/extension/src/content/FloatingIcon.tsx
+++ b/extension/src/content/FloatingIcon.tsx
@@ -147,6 +147,11 @@ const FloatingIcon: React.FC = () => {
     return googleAuthManager.getToken()
   }
 
+  // Function to get GitHub token for SWE-agent
+  const getGitHubToken = async () => {
+    return gitHubModeManager.getToken()
+  }
+
   // Set up mode state synchronization and cleanup on unmount
   useEffect(() => {
     // Register callback to sync UI state with edit mode state
@@ -430,7 +435,7 @@ const FloatingIcon: React.FC = () => {
         onAuthenticate={handleGitHubAuthenticate}
         onLogout={handleGitHubLogout}
         onSelectRepo={handleGitHubRepoSelect}
-        onGetToken={getGoogleToken}
+        onGetToken={getGitHubToken}
       />
 
       <SlackBubble


### PR DESCRIPTION
## Summary
- ensure SWE-Agent uses GitHub token instead of Google token when starting a job
- clarify GitHub token permissions in backend README

## Testing
- `pytest backend/SWE-agent/tests/test_env_utils.py::test_remove_triple_backticks -q` *(fails: ModuleNotFoundError: No module named 'swerex')*

------
https://chatgpt.com/codex/tasks/task_e_684bc68936fc8328b8da9679e9ae2ef1