### PR TITLE
Add draggable wrapper for floating pill

### DIFF
--- a/extension/src/content/DraggableWrapper.tsx
+++ b/extension/src/content/DraggableWrapper.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useRef, useEffect } from 'react'
+
+interface DraggableWrapperProps {
+  children: React.ReactNode
+}
+
+const DraggableWrapper: React.FC<DraggableWrapperProps> = ({ children }) => {
+  const iconSize = 44
+  const margin = 20
+  const [position, setPosition] = useState(() => ({
+    x: window.innerWidth - iconSize - margin,
+    y: window.innerHeight - iconSize - margin
+  }))
+  const dragging = useRef(false)
+  const offset = useRef({ x: 0, y: 0 })
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    dragging.current = true
+    offset.current = {
+      x: e.clientX - position.x,
+      y: e.clientY - position.y
+    }
+  }
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!dragging.current) return
+    setPosition({
+      x: e.clientX - offset.current.x,
+      y: e.clientY - offset.current.y
+    })
+  }
+
+  const onMouseUp = () => {
+    dragging.current = false
+  }
+
+  useEffect(() => {
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: position.x + 'px',
+        top: position.y + 'px',
+        cursor: dragging.current ? 'grabbing' : 'grab',
+        pointerEvents: 'auto',
+        zIndex: 2147483647
+      }}
+      onMouseDown={onMouseDown}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default DraggableWrapper

--- a/extension/src/content/content.tsx
+++ b/extension/src/content/content.tsx
@@ -1,6 +1,7 @@
 // React JSX transform handles React import automatically
 import { createRoot } from 'react-dom/client'
 import FloatingIcon from './FloatingIcon'
+import DraggableWrapper from './DraggableWrapper'
 import './content.css'
 
 // Function to inject the floating icon with Shadow DOM encapsulation
@@ -14,8 +15,8 @@ function injectFloatingIcon() {
   shadowHost.setAttribute('data-extension-id', 'designx-floating-icon')
   shadowHost.style.cssText = `
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    top: 0px;
+    left: 0px;
     z-index: 2147483647;
     pointer-events: none;
     width: 0;
@@ -67,8 +68,8 @@ function injectFloatingIcon() {
   reactContainer.id = 'floating-extension-icon'
   reactContainer.style.cssText = `
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    top: 0px;
+    left: 0px;
     z-index: 2147483647;
     pointer-events: none;
   `
@@ -79,7 +80,11 @@ function injectFloatingIcon() {
 
   // Create React root and render our component
   const root = createRoot(reactContainer)
-  root.render(<FloatingIcon />)
+  root.render(
+    <DraggableWrapper>
+      <FloatingIcon />
+    </DraggableWrapper>
+  )
 
   console.log('🎯 DesignX overlay injected with Shadow DOM encapsulation')
 }


### PR DESCRIPTION
## Summary
- implement `DraggableWrapper` for dragging the floating pill
- render `FloatingIcon` inside the new wrapper
- adjust injected container styles for wrapper usage

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bd8036d4c8328a1d885c220471152